### PR TITLE
Output dir static

### DIFF
--- a/src/main/java/com/felixgrund/codeshovel/util/Utl.java
+++ b/src/main/java/com/felixgrund/codeshovel/util/Utl.java
@@ -30,6 +30,8 @@ import java.util.Optional;
 public class Utl {
 
 	public static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("dd-MM-yyyy, HH:mm");
+	private static final String OUTPUT_BASE_DIR = Optional.ofNullable(
+			System.getenv("OUTPUT_DIR")).orElse(System.getProperty("user.dir") + "/output");
 
 	private static final Logger log = LoggerFactory.getLogger(Utl.class);
 
@@ -125,7 +127,7 @@ public class Utl {
 	public static void writeOutputFile(String subdir, String commitName, String filePath,
 				String functionId, String repoName, String content, String fileExtension) {
 
-		String baseDir = Optional.ofNullable( System.getenv("OUTPUT_DIR") ).orElse( System.getProperty("user.dir") + "/output" ) + "/" + subdir;
+		String baseDir = OUTPUT_BASE_DIR + "/" + subdir;
 		String commitNameShort = commitName.substring(0, 5);
 		String targetDirPath = baseDir + "/" + repoName;
 		if (functionId != null) {


### PR DESCRIPTION
@nickbradley This does not need to be done for every history write, correct? Meaning the output base dir .../output will remain the same during one execution.