### PR TITLE
Implemented GlobalEnv so we have all System.getenv calls in one place

### DIFF
--- a/src/main/java/com/felixgrund/codeshovel/execution/ShovelExecution.java
+++ b/src/main/java/com/felixgrund/codeshovel/execution/ShovelExecution.java
@@ -13,7 +13,6 @@ import com.felixgrund.codeshovel.tasks.GitRangeLogTask;
 import com.felixgrund.codeshovel.tasks.RecursiveAnalysisTask;
 import com.felixgrund.codeshovel.util.ParserFactory;
 import com.felixgrund.codeshovel.util.Utl;
-import com.google.gson.Gson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,7 +117,7 @@ public class ShovelExecution {
 		printAsJson(changeHistoryShort);
 
 		JsonResult jsonResultCodeshovel = new JsonResult("codeshovel", task, codeshovelHistory, changeHistoryDetails, changeHistoryShort);
-		Utl.writeJsonResultToFile(jsonResultCodeshovel);
+		Utl.writeShovelResultFile(jsonResultCodeshovel);
 		Utl.writeJsonStubToFile(jsonResultCodeshovel);
 
 		GitRangeLogTask gitRangeLogTask = new GitRangeLogTask(task, startEnv);
@@ -127,7 +126,7 @@ public class ShovelExecution {
 
 		JsonResult jsonResultLogCommand = new JsonResult("logcommand", task, gitLogHistory, null, null);
 		Utl.printMethodHistory(gitLogHistory);
-		Utl.writeJsonResultToFile(jsonResultLogCommand);
+		Utl.writeGitLogFile(jsonResultLogCommand);
 
 		createAndWriteSemanticDiff("gitlog", jsonResultCodeshovel, codeshovelHistory, gitLogHistory);
 

--- a/src/main/java/com/felixgrund/codeshovel/wrappers/GlobalEnv.java
+++ b/src/main/java/com/felixgrund/codeshovel/wrappers/GlobalEnv.java
@@ -1,0 +1,25 @@
+package com.felixgrund.codeshovel.wrappers;
+
+import java.util.Optional;
+
+public class GlobalEnv {
+
+	public static final String REPO_DIR = System.getenv("REPO_DIR");
+	public static final String ENV_NAME = System.getenv("ENV_NAME");
+	public static final String OUTPUT_DIR = Optional.ofNullable(
+			System.getenv("OUTPUT_DIR")).orElse(System.getProperty("user.dir") + "/output");
+
+	public static final boolean DISABLE_ALL_OUTPUTS = Boolean.valueOf(System.getenv("DISABLE_ALL_OUTPUTS"));
+	public static final boolean WRITE_GIT_DIFFS = Boolean.valueOf(System.getenv("WRITE_GIT_DIFFS"));
+	public static final boolean WRITE_SEMANTIC_DIFFS = Boolean.valueOf(System.getenv("WRITE_SEMANTIC_DIFFS"));
+	public static final boolean WRITE_RESULTS = Boolean.valueOf(System.getenv("WRITE_RESULTS"));
+	public static final boolean WRITE_GITLOG = Boolean.valueOf(System.getenv("WRITE_GITLOG"));
+	public static final boolean WRITE_STUBS = Boolean.valueOf(System.getenv("WRITE_STUBS"));
+	public static final boolean WRITE_SIMILARITIES = Boolean.valueOf(System.getenv("WRITE_SIMILARITIES"));
+
+	// Only for mining:
+	public static final String TARGET_FILE_PATH = System.getenv("TARGET_FILE_PATH");
+	public static final String REPO = System.getenv("REPO");
+	public static final String START_COMMIT = System.getenv("START_COMMIT");
+
+}

--- a/src/test/java/com/felixgrund/codeshovel/AnalysisTaskTest.java
+++ b/src/test/java/com/felixgrund/codeshovel/AnalysisTaskTest.java
@@ -7,6 +7,7 @@ import com.felixgrund.codeshovel.execution.ShovelExecution;
 import com.felixgrund.codeshovel.services.RepositoryService;
 import com.felixgrund.codeshovel.services.impl.CachingRepositoryService;
 import com.felixgrund.codeshovel.util.Utl;
+import com.felixgrund.codeshovel.wrappers.GlobalEnv;
 import com.felixgrund.codeshovel.wrappers.StartEnvironment;
 import com.google.gson.Gson;
 import org.apache.commons.io.FileUtils;
@@ -31,15 +32,12 @@ public class AnalysisTaskTest {
 
 	private static Logger log = LoggerFactory.getLogger(AnalysisTaskTest.class);
 
-	private static final String CODESTORY_REPO_DIR = System.getenv("REPO_DIR");
-	private static final String STUBS_DIR = "stubs/java";
+	private static final String CODESTORY_REPO_DIR = GlobalEnv.REPO_DIR;
+	private static final String STUBS_DIR = "stubs/java"; // TODO
 
 	private static final Gson GSON = new Gson();
 
-	// Specify file name (without file extension) if you want to run only a single test.
-	// e.g. "checkstyle-Checker-fireErrors";
-//	private static final String RUN_ONLY_TEST = "flink-LocatableInputSplitAssigner-getNextInputSplit";
-	private static final String RUN_ONLY_TEST = System.getenv("ENV_NAME");
+	private static final String RUN_ONLY_TEST = GlobalEnv.ENV_NAME;
 
 	private static List<StartEnvironment> startEnvs = new ArrayList<>();
 

--- a/src/test/java/com/felixgrund/codeshovel/MainAnalysisTask.java
+++ b/src/test/java/com/felixgrund/codeshovel/MainAnalysisTask.java
@@ -4,6 +4,7 @@ import com.felixgrund.codeshovel.execution.ShovelExecution;
 import com.felixgrund.codeshovel.services.RepositoryService;
 import com.felixgrund.codeshovel.services.impl.CachingRepositoryService;
 import com.felixgrund.codeshovel.util.Utl;
+import com.felixgrund.codeshovel.wrappers.GlobalEnv;
 import com.felixgrund.codeshovel.wrappers.StartEnvironment;
 import com.google.gson.Gson;
 import org.apache.commons.io.FileUtils;
@@ -17,8 +18,6 @@ import java.util.Date;
 public class MainAnalysisTask {
 
 	private static final String LANG = "java";
-	private static final String TEST_CONFIG = System.getenv("ENV_NAME");
-	private static final String CODESTORY_REPO_DIR = System.getenv("REPO_DIR");
 
 	public static void main(String[] args) throws Exception {
 		long start = new Date().getTime();
@@ -28,7 +27,7 @@ public class MainAnalysisTask {
 	}
 
 	public static void execute() throws Exception {
-		String configName = TEST_CONFIG;
+		String configName = GlobalEnv.ENV_NAME;
 		ClassLoader classLoader = MainAnalysisTask.class.getClassLoader();
 		File file = new File(classLoader.getResource("stubs/" + LANG + "/" + configName + ".json").getFile());
 		String json = FileUtils.readFileToString(file, "utf-8");
@@ -36,7 +35,7 @@ public class MainAnalysisTask {
 
 		StartEnvironment startEnv = gson.fromJson(json, StartEnvironment.class);
 		String repositoryName = startEnv.getRepositoryName();
-		String repositoryPath = CODESTORY_REPO_DIR + "/" + repositoryName + "/.git";
+		String repositoryPath = GlobalEnv.REPO_DIR + "/" + repositoryName + "/.git";
 		startEnv.setRepositoryPath(repositoryPath);
 
 		Repository repository = Utl.createRepository(repositoryPath);

--- a/src/test/java/com/felixgrund/codeshovel/MiningTestJava.java
+++ b/src/test/java/com/felixgrund/codeshovel/MiningTestJava.java
@@ -1,26 +1,28 @@
 package com.felixgrund.codeshovel;
 
+import com.felixgrund.codeshovel.wrappers.GlobalEnv;
+
 public class MiningTestJava extends MiningTest {
 
 // Sample run
 	static {
-		TARGET_FILE_EXTENSION = ".java";
-		CODESTORY_REPO_DIR = System.getenv("REPO_DIR");
+//		TARGET_FILE_EXTENSION = ".java";
+//		CODESTORY_REPO_DIR = GlobalEnv.REPO_DIR;
 
 //		TARGET_FILE_PATH = "flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java";
-		TARGET_FILE_PATH = "src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java";
+//		TARGET_FILE_PATH = "src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java";
 
 
 		REPO = "checkstyle";
 //		REPO = "flink";
 //		START_COMMIT = "9e936a5f8198b0059e9b5fba33163c2bbe3efbdd";
-		START_COMMIT = "119fd4fb33bef9f5c66fc950396669af842c21a3";
+//		START_COMMIT = "119fd4fb33bef9f5c66fc950396669af842c21a3";
 
 
 		// Specify a method name if you only want to consider methods with that name.
 		// If you want to run it on all methods (which will be most cases for mining), use `null`.
 
-		TARGET_METHOD = "processFiltered";
+//		TARGET_METHOD = "processFiltered";
 //		TARGET_METHOD = "deserialize";
 
 		// Specify a method line number if you want to use only methods with name TARGET_METHOD *and* TARGET_METHOD_STARTLINE.
@@ -29,21 +31,21 @@ public class MiningTestJava extends MiningTest {
 	}
 
 
-//	static {
-//		TARGET_FILE_EXTENSION = ".java";
-//		TARGET_FILE_PATH = System.getenv("TARGET_FILE_PATH");
-//		CODESTORY_REPO_DIR = System.getenv("REPO_DIR");
-//		REPO = System.getenv("REPO");
-//		START_COMMIT = System.getenv("START_COMMIT");
-//
-//		// Specify a method name if you only want to consider methods with that name.
-//		// If you want to run it on all methods (which will be most cases for mining), use `null`.
-//		TARGET_METHOD = null;
-//
-//		// Specify a method line number if you want to use only methods with name TARGET_METHOD *and* TARGET_METHOD_STARTLINE.
-//		// If the start line doesn't matter (which will be most cases for mining), use `0`.
-//		TARGET_METHOD_STARTLINE = 0;
-//	}
+	static {
+		TARGET_FILE_EXTENSION = ".java";
+		TARGET_FILE_PATH = GlobalEnv.TARGET_FILE_PATH;
+		CODESTORY_REPO_DIR = GlobalEnv.REPO_DIR;
+		REPO = GlobalEnv.REPO;
+		START_COMMIT = GlobalEnv.START_COMMIT;
+
+		// Specify a method name if you only want to consider methods with that name.
+		// If you want to run it on all methods (which will be most cases for mining), use `null`.
+		TARGET_METHOD = null;
+
+		// Specify a method line number if you want to use only methods with name TARGET_METHOD *and* TARGET_METHOD_STARTLINE.
+		// If the start line doesn't matter (which will be most cases for mining), use `0`.
+		TARGET_METHOD_STARTLINE = 0;
+	}
 
 
 

--- a/src/test/java/com/felixgrund/codeshovel/MiningTestJs.java
+++ b/src/test/java/com/felixgrund/codeshovel/MiningTestJs.java
@@ -1,5 +1,7 @@
 package com.felixgrund.codeshovel;
 
+import com.felixgrund.codeshovel.wrappers.GlobalEnv;
+
 public class MiningTestJs extends MiningTest {
 
 	private static final boolean METHOD_MODE = false;
@@ -7,7 +9,7 @@ public class MiningTestJs extends MiningTest {
 	static {
 		TARGET_FILE_EXTENSION = ".js";
 		TARGET_FILE_PATH = "src/css.js";
-		CODESTORY_REPO_DIR = System.getenv("REPO_DIR");
+		CODESTORY_REPO_DIR = GlobalEnv.REPO_DIR;
 		REPO = "jquery";
 		START_COMMIT = "45f085882597016e521436f01a8459daf3e4000e";
 


### PR DESCRIPTION
There is now a GlobalEnv class that has all our environment. In your Docker container, you'll only have to set these environment variables:
```
WRITE_RESULTS = true
WRITE_SEMANTIC_DIFFS = true
```
Then only the two files that are needed will be written.