### PR TITLE
Feature #75 Track formatting changes

### DIFF
--- a/src/main/java/com/felixgrund/codeshovel/changes/Yformatchange.java
+++ b/src/main/java/com/felixgrund/codeshovel/changes/Yformatchange.java
@@ -1,0 +1,10 @@
+package com.felixgrund.codeshovel.changes;
+
+import com.felixgrund.codeshovel.parser.Yfunction;
+import com.felixgrund.codeshovel.wrappers.StartEnvironment;
+
+public class Yformatchange extends Ycomparefunctionchange {
+    public Yformatchange(StartEnvironment startEnv, Yfunction newFunction, Yfunction oldFunction) {
+        super(startEnv, newFunction, oldFunction);
+    }
+}

--- a/src/main/java/com/felixgrund/codeshovel/parser/AbstractFunction.java
+++ b/src/main/java/com/felixgrund/codeshovel/parser/AbstractFunction.java
@@ -50,6 +50,8 @@ public abstract class AbstractFunction<E> implements Yfunction {
 	private String sourceFragment;
 	private String functionDoc;
 	protected abstract String getInitialDoc(E rawMethod);
+	private String unformattedBody;
+	protected abstract String getInitialUnformattedBody(E rawMethod);
 
 	public AbstractFunction(E rawMethod, Commit commit, String sourceFilePath, String sourceFileContent) {
 		this.commit = commit;
@@ -71,8 +73,9 @@ public abstract class AbstractFunction<E> implements Yfunction {
 		this.functionPath = getInitialFunctionPath(rawMethod);
 		this.returnStmt = getInitialReturnStmt(rawMethod); // Must be called after getInitialType
 		this.annotation = getInitialAnnotation(rawMethod);
-		this.sourceFragment = getInitialSourceFragment(rawMethod); // Must be called after begin/endLine
 		this.functionDoc = getInitialDoc(rawMethod);
+		this.unformattedBody = getInitialUnformattedBody(rawMethod);
+		this.sourceFragment = getInitialSourceFragment(rawMethod); // Must be called after begin/endLine
 	}
 
 	protected String getIdParameterString() {
@@ -207,5 +210,10 @@ public abstract class AbstractFunction<E> implements Yfunction {
 	@Override
 	public String getFunctionDoc() {
 		return this.functionDoc;
+	}
+
+	@Override
+	public String getUnformattedBody() {
+		return this.unformattedBody;
 	}
 }

--- a/src/main/java/com/felixgrund/codeshovel/parser/AbstractParser.java
+++ b/src/main/java/com/felixgrund/codeshovel/parser/AbstractParser.java
@@ -64,6 +64,15 @@ public abstract class AbstractParser implements Yparser {
         return ret;
     }
 
+    protected Yformatchange getFormatChange(Ycommit commit, Yfunction compareFunction) {
+        Yformatchange ret = null;
+        Yfunction function = commit.getMatchedFunction();
+        if (Utl.isFormatChange(function, compareFunction)) {
+            ret = new Yformatchange(this.startEnv, commit.getMatchedFunction(), compareFunction);
+        }
+        return ret;
+    }
+
     protected Yreturntypechange getReturnTypeChange(Ycommit commit, Yfunction compareFunction) {
         Yreturntypechange ret = null;
         Yreturn returnA = compareFunction.getReturnStmt();

--- a/src/main/java/com/felixgrund/codeshovel/parser/Yfunction.java
+++ b/src/main/java/com/felixgrund/codeshovel/parser/Yfunction.java
@@ -109,4 +109,9 @@ public interface Yfunction {
 	 * */
 	String getFunctionDoc();
 
+	/***
+	 * @return the unformatted method's body preserving whitespace, indentation and other formatting
+	 */
+	String getUnformattedBody();
+
 }

--- a/src/main/java/com/felixgrund/codeshovel/parser/impl/JavaFunction.java
+++ b/src/main/java/com/felixgrund/codeshovel/parser/impl/JavaFunction.java
@@ -15,7 +15,9 @@ import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
 import com.github.javaparser.ast.type.ReferenceType;
+import com.github.javaparser.printer.PrettyPrinter;
 import com.github.javaparser.printer.PrettyPrinterConfiguration;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
@@ -202,5 +204,11 @@ public class JavaFunction extends AbstractFunction<MethodDeclaration> implements
 	@Override
 	protected String getInitialDoc(MethodDeclaration method) {
 		return method.hasJavaDocComment() ? method.getJavadoc().get().toText() : "" ;
+	}
+
+	@Override
+	protected String getInitialUnformattedBody(MethodDeclaration method) {
+		LexicalPreservingPrinter.setup(method);
+		return LexicalPreservingPrinter.print(method.getBody().get());
 	}
 }

--- a/src/main/java/com/felixgrund/codeshovel/parser/impl/JavaParser.java
+++ b/src/main/java/com/felixgrund/codeshovel/parser/impl/JavaParser.java
@@ -71,6 +71,7 @@ public class JavaParser extends AbstractParser implements Yparser {
         Ymodifierchange ymodifierchange = getModifiersChange(commit, compareFunction);
         Yexceptionschange yexceptionschange = getExceptionsChange(commit, compareFunction);
         Ybodychange ybodychange = getBodyChange(commit, compareFunction);
+        Yformatchange yformatchange = getFormatChange(commit, compareFunction);
         Yparametermetachange yparametermetachange = getParametersMetaChange(commit, compareFunction);
         Yannotationchange yannotationchange = getAnnotationChange(commit, compareFunction);
         Ydocchange ydocchange = getDocChange(commit, compareFunction);
@@ -95,6 +96,9 @@ public class JavaParser extends AbstractParser implements Yparser {
         }
         if (ydocchange != null) {
             changes.add(ydocchange);
+        }
+        if (yformatchange != null) {
+            changes.add(yformatchange);
         }
         return changes;
     }

--- a/src/main/java/com/felixgrund/codeshovel/parser/impl/PythonFunction.java
+++ b/src/main/java/com/felixgrund/codeshovel/parser/impl/PythonFunction.java
@@ -162,6 +162,12 @@ public class PythonFunction extends AbstractFunction<PythonParser.FuncdefContext
     }
 
     @Override
+    protected String getInitialUnformattedBody(PythonParser.FuncdefContext rawMethod) {
+        // TODO: implement function for python
+        return null;
+    }
+
+    @Override
     protected String getInitialSourceFragment(PythonParseTree.PythonParser.FuncdefContext function) {
         // Note: This will not work on lambdas
         int startWithDecorators;

--- a/src/main/java/com/felixgrund/codeshovel/parser/impl/TypeScriptFunction.java
+++ b/src/main/java/com/felixgrund/codeshovel/parser/impl/TypeScriptFunction.java
@@ -167,6 +167,12 @@ public class TypeScriptFunction extends AbstractFunction<V8Object> implements Yf
     }
 
     @Override
+    protected String getInitialUnformattedBody(V8Object rawMethod) {
+        // TODO: implement function for typescript
+        return null;
+    }
+
+    @Override
     protected String getInitialSourceFragment(V8Object rawMethod) {
         int startLine = rawMethod.getInteger("startLine");
         int endLine = getEndLineNumber();

--- a/src/main/java/com/felixgrund/codeshovel/util/Utl.java
+++ b/src/main/java/com/felixgrund/codeshovel/util/Utl.java
@@ -348,4 +348,27 @@ public class Utl {
 
 		return false;
 	}
+
+	/***
+	 * Check for formatting changes
+	 * <p>
+	 *     If indentation, whitespace or any sort of formatting
+	 *     was performed on a method the function will return true.
+	 *     Otherwise it will return false.
+	 * </p>
+	 * @param function current matched function
+	 * @param compareFunction previous function to compare with
+	 * @return boolean True/False
+	 */
+	public static boolean isFormatChange(Yfunction function, Yfunction compareFunction) {
+		// if lexically preserved method's body (unformatted body) are not equal
+		// but pretty printed method's body (ignoring whitespace, indentation etc.,) are equal
+		// then the change was of Yformatchange type
+		if (function != null && compareFunction != null &&
+				function.getBody().equals(compareFunction.getBody()) &&
+				!function.getUnformattedBody().equals(compareFunction.getUnformattedBody())) {
+			return true;
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
- Get the unformatted body by preserving the original layout of the source code
- Compare between current and previous unformatted method's body to track these
  kind of formatting changes
- Use Javaparser "LexicalPreservingPrinter" to get the unformatted source code